### PR TITLE
Changing time format and Tensorflow variable initializer function

### DIFF
--- a/tyrion/backprop_tf.py
+++ b/tyrion/backprop_tf.py
@@ -24,7 +24,7 @@ class TrainModel(object):
         self.loss = tf.reduce_sum((self.inputs - self.recons)**2) + reg1 * tf.reduce_sum(self.W1 ** 2) + reg2 * tf.reduce_sum(self.W2 ** 2)
         self.train = tf.train.RMSPropOptimizer(learnrate, 0.9).minimize(self.loss)
         self.session = tf.Session()
-        tf.initialize_all_variables().run(session=self.session)    
+        tf.global_variables_initializer().run(session=self.session)  
 
        
     def trainonone(self, pa, ntimes):    

--- a/tyrion/train.py
+++ b/tyrion/train.py
@@ -12,6 +12,7 @@ import numpy as np
 import argparse
 import time
 import pdb
+import datetime
 
 
 CONFIG_PATH = sys.argv[1]
@@ -104,7 +105,9 @@ def train(folder):
     with open(r'./embeddings.pickle', "wb") as outfile:
         pickle.dump(wordembeddings, outfile)
     print ("Training completed! Embedding done.")
-    print ("time is %f" % (time.time()-t))
+    sec = time.time() - t 
+    hours, minutes, seconds = str(datetime.timedelta(seconds=sec)).split(':')
+    print "Training took : {0} hours, {1} minutes, {2} seconds".format(hours,minutes,seconds)    
 
 if __name__ == "__main__":
     train(DATA_PATH)


### PR DESCRIPTION
This PR : 

1) Changes the time format of the training time for better readability

2) Changes tf.initialize_all_variables() to tf.global_variables_initializer() since the former is deprecated and will be removed soon.